### PR TITLE
feat: 부스 목록 필터링 항목 추가

### DIFF
--- a/account/views.py
+++ b/account/views.py
@@ -60,7 +60,10 @@ class LikedListView(views.APIView):
 
     def get(self, request):
         user = request.user
-        booths = Booth.objects.filter(like=user.id)
+        keyword= request.GET.get('keyword')
+        
+        booths = (Booth.objects.filter(like=user.id) & (Booth.objects.filter(category__icontains=keyword) | 
+                           Booth.objects.filter(day__day__icontains=keyword) | Booth.objects.filter(college__icontains=keyword))).distinct()
 
         for booth in booths:
             booth.is_liked=True

--- a/booth/views.py
+++ b/booth/views.py
@@ -31,8 +31,9 @@ class BoothListView(views.APIView, PaginationHandlerMixin):
         
         day = request.GET.get('day')
         college = request.GET.get('college')
+        category = request.GET.get('category')
 
-        params = {'day': day, 'college': college}
+        params = {'day': day, 'college': college, 'category': category}
         arguments = {}
         for key, value in params.items():
             if value:


### PR DESCRIPTION
## Solved Issue

close #61

<br>

## Motivation

- 제가 카톡에서는 함수를 따로 구현했는데 굳이 그럴 이유가 없더라구요?? BoothListView랑 LikedListView만 수정해서 url은 안건드렸습니다.
- BoothListView는 day, college, category로 따로 받아오고, LikedListView에서는 그냥 keyword(char)로 받아오는 걸로...어짜피 동시검색 안하드라구요 피그마 보니까

<br>

## Key Changes

- 부스목록 필터링에 카테고리 항목 추가(category)
- LikedListView에 필터링 추가(keyword)

![날짜 좋아요 필터링](https://user-images.githubusercontent.com/102947194/230831700-16a6443c-30a7-4d9d-aa4c-58c2555d8dfc.png)

![카테고리 좋아요 필터링](https://user-images.githubusercontent.com/102947194/230831716-8a53b1b1-5524-4417-b09d-5f7ef328b1cf.png)



<br>

## To Reviewers

- 잘되는거 확인되면 노션페이지 수정하겠습니다~